### PR TITLE
Extending the OSC API?

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # seq192
 
+Fork infos:
+- Adding some OSC commands:
+  Command base is /sequence/edit edit_mode sequence_name args...
+  - set sequence length : `sendosc 127.0.0.1 9000 /sequence/edit s beats s Untitled i 4 i 4 i 2` 4/4 x 2, 6/8 x 4 etc...
+  - add note : `sendosc 127.0.0.1 9000 /sequence/edit s add_note s Untitled i 16 i 8 i 60` start tick, length, midi pitch (start and length in 64th)
+  - remove note : `sendosc 127.0.0.1 9000 /sequence/edit s delete_note s Untitled i 16 i 60` start tick, midi pitch (start also in 64th)
+
 MIDI sequencer based on seq24 with less features and more swag.
 
 **Less features**

--- a/src/core/perform.cpp
+++ b/src/core/perform.cpp
@@ -144,6 +144,95 @@ int perform::osc_callback(const char *path, const char *types, lo_arg ** argv,
         case SEQ_PANIC:
             self->panic();
             break;
+        case SEQ_SEQ_EDIT:
+        {
+            if (argc < 1 || types[0] != 's') return 0;
+
+            // arg 0: mode
+            int mode = self->osc_seq_edit_modes[(std::string) &argv[0]->s];
+            if (!mode) return 1;
+
+            int t_seq = -1; // target seq
+            int next = -1;
+            // sequence selection
+            if (types[1] == 'i') {
+                // arg 1: column number
+                int col = argv[1]->i;
+                if (col < 0 || col > c_mainwnd_cols) return 1;
+                // arg 2: row number
+                if (types[2] == 'i') {
+                    int row = argv[2]->i;
+                    if (row < c_mainwnd_rows) {
+                        t_seq = (row + col * c_mainwnd_rows) + self->m_screen_set * c_mainwnd_cols * c_mainwnd_rows;
+                        if (self->is_active(t_seq))
+                            next = 3; // command mode arguments start at index 3
+                    }
+                } else return 1;
+            } else if (types[1] == 's') {
+                // arg 1: sequence name / osc pattern
+                for (int i = 0; i < c_mainwnd_cols * c_mainwnd_rows; i++) {
+                    int nseq = i + self->m_screen_set * c_mainwnd_cols * c_mainwnd_rows;
+                    if (self->is_active(nseq)) {
+                        if (lo_pattern_match(self->m_seqs[nseq]->get_name(), &argv[1]->s)) {
+                            t_seq = nseq;
+                            next = 2; // command mode arguments start at index 2
+                            break;
+                        }
+                    }
+                }
+            }
+            if (next < 0 || t_seq < 0) return 1;
+            int mode_argc = argc - next;
+            switch (mode) {
+                case SEQ_MODE_TICKS:
+                    if (mode_argc != 1 && types[next] != 'i') return 1;
+                    // printf("Sequence: %s Set length: %d\n", self->m_seqs[t_seq]->get_name(), argv[next]->i);
+                    self->m_seqs[t_seq]->set_length(argv[next]->i);
+                    self->m_seqs[t_seq]->set_dirty();
+                    break;
+                case SEQ_MODE_BEATS:
+                {
+                    if (mode_argc != 3 || types[next] != 'i' || types[next+1] != 'i'|| types[next+2] != 'i') return 1;
+                    int bpm = argv[next]->i;
+                    int bw = argv[next+1]->i;
+                    int measures = argv[next+2]->i;
+                    self->m_seqs[t_seq]->set_bpm(bpm);
+                    self->m_seqs[t_seq]->set_bw(bw);
+                    self->m_seqs[t_seq]->set_length(measures * bpm * ((c_ppqn * 4) / bw));
+                    // printf("Set length, bpm, bw %ld %ld\n", self->m_seqs[t_seq]->get_bpm(), self->m_seqs[t_seq]->get_bw());
+                    self->m_seqs[t_seq]->set_dirty();
+                    break;
+                }
+                case SEQ_MODE_ADD_NOTE:
+                {   
+                    constexpr int snap = c_ppqn / 16;
+                    if (mode_argc != 3 || types[next] != 'i' || types[next+1] != 'i'|| types[next+2] != 'i') return 1;
+                    int at = argv[next]->i;
+                    int len = argv[next+1]->i;
+                    int note = argv[next+2]->i;
+                    if (at < 0 || len < 0 || note < 0) return 1;
+                    at *= snap;
+                    len *= snap;
+                    if (note > 127) note = 127;
+                    // printf("Adding note: tick=%d, length=%d, pitch=%d\n", at, len, note);
+                    self->m_seqs[t_seq]->add_note(at, len, note, true);
+                    self->m_seqs[t_seq]->set_dirty();
+                    break;
+                }
+                case SEQ_MODE_DELETE_NOTE:
+                {
+                    constexpr int snap = c_ppqn / 16;
+                    if (mode_argc != 2 || types[next] != 'i' || types[next+1] != 'i') return 1;
+                    int at = argv[next]->i;
+                    int note = argv[next+1]->i;
+                    at *= snap;
+                    int ret = self->m_seqs[t_seq]->select_note_events(at, note, at, note, sequence::e_remove_one);
+                    if (!ret) return 1;
+                    break;
+                }
+            }
+            break;
+        }
         case SEQ_SSEQ:
         case SEQ_SSEQ_AND_PLAY:
         case SEQ_SSEQ_QUEUED:
@@ -278,6 +367,8 @@ int perform::osc_callback(const char *path, const char *types, lo_arg ** argv,
                             case SEQ_MODE_DELETE:
                                 self->delete_sequence(nseq);
                                 break;
+                            case SEQ_MODE_TICKS:
+                                printf("Selected has name: %s\n", self->m_seqs[nseq]->get_name());
                         }
                     } else if (nseq < c_max_sequence && !self->is_active(nseq)) {
                         switch (mode) {

--- a/src/core/perform.h
+++ b/src/core/perform.h
@@ -206,6 +206,7 @@ class perform
         SEQ_SSEQ_QUEUED,
         SEQ_STATUS,
         SEQ_STATUS_EXT,
+        SEQ_SEQ_EDIT,
 
         SEQ_MODE_SOLO,
         SEQ_MODE_ON,
@@ -220,6 +221,11 @@ class perform
         SEQ_MODE_DELETE,
         SEQ_MODE_CLEAR,
 
+        SEQ_MODE_TICKS,
+        SEQ_MODE_BEATS,
+        SEQ_MODE_ADD_NOTE,
+        SEQ_MODE_DELETE_NOTE,
+
     };
 
     std::map<std::string, int> osc_commands = {
@@ -232,7 +238,8 @@ class perform
         {"/sequence/trig",      SEQ_SSEQ_AND_PLAY},
         {"/sequence/queue",     SEQ_SSEQ_QUEUED},
         {"/status",             SEQ_STATUS},
-        {"/status/extended",    SEQ_STATUS_EXT}
+        {"/status/extended",    SEQ_STATUS_EXT},
+        {"/sequence/edit",      SEQ_SEQ_EDIT},
     };
 
     std::map<std::string, int> osc_seq_modes = {
@@ -250,6 +257,12 @@ class perform
         {"clear",               SEQ_MODE_CLEAR}
     };
 
+    std::map<std::string, int> osc_seq_edit_modes = {
+        {"ticks",               SEQ_MODE_TICKS},
+        {"beats",               SEQ_MODE_BEATS},
+        {"add_note",            SEQ_MODE_ADD_NOTE},
+        {"delete_note",         SEQ_MODE_DELETE_NOTE},
+    };
 
     friend class mainwid;
     friend class midifile;


### PR DESCRIPTION
Hello!

I had a try at adding some new commands to the OSC API and it turned out to be really simple, thank you for laying out all the code as neatly as it is!

New things are:
- change sequence length, beat per measure, beat length and measures
- add and remove notes, snapping at 64th notes

I'm opening a PR for anyone to test and as I wish to contribute but this is more of a discussion about *how* and *why* extending the API. What are your thoughts about that?

My initial idea was to make editing sequences while playing live using MIDI controllers or other interactions. I'm mostly working on making modules for VCV Rack although seq192 is exciting to use and experiment with as it is very lightweight.

Speaking of lightweight, as a bonus and a little Makefile exercise, I've made seq192 into a lib in a separate branch [here](https://github.com/Simon-L/seq192/commit/20d3393fbcd7052e20d45f27951b3e2ed9af0d95). Would there be any interest in stripping it even more? I'm thinking even removing jack and gtk to have a very cool embeddable sequencer engine.