### PR TITLE
color sequence button with the color found in config file

### DIFF
--- a/src/core/configfile.cpp
+++ b/src/core/configfile.cpp
@@ -82,6 +82,11 @@ ConfigFile::parse()
                         global_user_instrument_definitions[instrument_number].instrument = channel_name;
                     }
 
+                    auto channel_color = channel_data["color"];
+                    if (channel_color.is_string()){
+                        global_user_instrument_definitions[instrument_number].color = channel_color;
+                    }
+
                     auto controls = channel_data["controls"];
                     if (controls.is_object()) {
                         for (json::iterator it = controls.begin(); it != controls.end(); ++it) {

--- a/src/core/globals.h
+++ b/src/core/globals.h
@@ -97,6 +97,7 @@ struct user_midi_bus_definition
 struct user_instrument_definition
 {
     string instrument;
+    string color;
     bool controllers_active[128];
     string controllers[128];
 };

--- a/src/gui/sequencebutton.cpp
+++ b/src/gui/sequencebutton.cpp
@@ -103,20 +103,7 @@ SequenceButton::draw_background()
         cr->rectangle(0, 0, width, height);
         cr->fill();
 
-        // background colored if present in config file for this instrument
-        int instrument_number = seq->get_midi_channel() + seq->get_midi_bus() * 16;
-        string color_name = global_user_instrument_definitions[instrument_number].color;
-
-        if (! color_name.empty()){
-            const Gdk::RGBA c_chan_col = Gdk::RGBA(color_name.c_str());
-            cr->set_source_rgba(
-                c_chan_col.get_red(),
-                c_chan_col.get_green(),
-                c_chan_col.get_blue(),
-                0.125);
-            cr->rectangle(0, 0, width, height);
-            cr->fill();
-        }
+        
 
         // font
         Pango::FontDescription font;
@@ -140,17 +127,34 @@ SequenceButton::draw_background()
             queued->show_in_cairo_context(cr);
         }
 
-        // name
-        color = seq->get_playing() ? c_sequence_text_on : c_sequence_text;
-        if (get_sequence()->get_recording()) {
-            color = c_sequence_text_record;
-        }
-        cr->set_source_rgb(color.r, color.g, color.b);
+        // prepare the text, it will define the text_height needed for the next step
         auto name = create_pango_layout(seq->get_name());
         name->set_font_description(font);
         name->get_pixel_size(text_width, text_height);
         name->set_width((width - c_sequence_padding * 2 - queued_width) * Pango::SCALE);
         name->set_ellipsize(Pango::ELLIPSIZE_END);
+
+        // background colored if present in config file for this instrument
+        int instrument_number = seq->get_midi_channel() + seq->get_midi_bus() * 16;
+        string color_name = global_user_instrument_definitions[instrument_number].color;
+
+        if (! color_name.empty()){
+            const Gdk::RGBA c_chan_col = Gdk::RGBA(color_name.c_str());
+            cr->set_source_rgba(
+                c_chan_col.get_red(),
+                c_chan_col.get_green(),
+                c_chan_col.get_blue(),
+                0.4);
+            cr->rectangle(0, 0, width, c_sequence_padding * 2 + text_height * 2);
+            cr->fill();
+        }
+
+        // print the name
+        color = seq->get_playing() ? c_sequence_text_on : c_sequence_text;
+        if (get_sequence()->get_recording()) {
+            color = c_sequence_text_record;
+        }
+        cr->set_source_rgb(color.r, color.g, color.b);
         cr->move_to(c_sequence_padding, c_sequence_padding);
         name->show_in_cairo_context(cr);
 
@@ -171,6 +175,8 @@ SequenceButton::draw_background()
         timesig->set_ellipsize(Pango::ELLIPSIZE_END);
         cr->move_to(c_sequence_padding, c_sequence_padding + text_height);
         timesig->show_in_cairo_context(cr);
+
+        
 
         // events
         cr->set_source_rgba(color.r, color.g, color.b, 0.1);

--- a/src/gui/sequencebutton.cpp
+++ b/src/gui/sequencebutton.cpp
@@ -16,6 +16,7 @@
 
 #include "sequencebutton.h"
 #include "editwindow.h"
+#include "../core/globals.h"
 
 SequenceButton::SequenceButton(perform * p, MainWindow * m, int seqpos)
 {
@@ -97,10 +98,25 @@ SequenceButton::draw_background()
         color color;
 
         // background
-        color = seq->get_playing() ? c_sequence_background_on : c_sequence_background;
+        color = seq->get_playing() ? c_sequence_background_on : c_sequence_background;        
         cr->set_source_rgb(color.r, color.g, color.b);
         cr->rectangle(0, 0, width, height);
         cr->fill();
+
+        // background colored if present in config file for this instrument
+        int instrument_number = seq->get_midi_channel() + seq->get_midi_bus() * 16;
+        string color_name = global_user_instrument_definitions[instrument_number].color;
+
+        if (! color_name.empty()){
+            const Gdk::RGBA c_chan_col = Gdk::RGBA(color_name.c_str());
+            cr->set_source_rgba(
+                c_chan_col.get_red(),
+                c_chan_col.get_green(),
+                c_chan_col.get_blue(),
+                0.125);
+            cr->rectangle(0, 0, width, height);
+            cr->fill();
+        }
 
         // font
         Pango::FontDescription font;


### PR DESCRIPTION
![Screenshot_seq192_colors](https://user-images.githubusercontent.com/3808689/213677155-05ad7eb6-3648-439e-a713-b501b2e5bf13.png)

Enable to set a color for instrument in config file, for faster identification.

Config file example:
```
{
    "buses": {
        "0": {
            "name": "Sampler",
            "channels": {
                "0": {
                    "name": "Drums",
                    "notes": {"36": "Kick", "37": "Snare", "38": "Snare flam", "39": "Snare side stick", "40": "Snare roll", "41": "Snare rim shot", "42": "Snare drag", "44": "HH1 closed", "45": "HH1 open", "46": "HH1 pedal", "47": "Hats2 crash", "48": "Hats2 bell", "49": "Hats2 shack", "50": "Tom 10\"", "51": "Tom 10\" flam", "52": "Tom 13\"", "53": "Tom 13\" flams", "54": "Ride 22\"", "55": "Ride 22\" bell", "56": "Splash 6\"", "57": "Splash 6\" choke", "58": "Crash 14\"", "59": "Crash 18\" choke", "60": "Crash 18\""},
                    "controls": {
                        "1": "Custom cc name ",
                        "2": "Etc"
                    }
                },
                "1": {
                    "name": "DrumsElectro",
                    "color": "maroon",
                    "notes": {"36": "Kick 1", "37": "Kick 2", "38": "Kick 3", "39": "Snare", "40": "Clap 1", "41": "Clap 2", "44": "Closed HH 1", "45": "Closed HH 2", "46": "Closed HH 3", "47": "Closed HH 4", "48": "Open HH", "49": "Side HH", "50": "Side OHH", "51": "Zap 1", "52": "Zap 2", "53": "FX"},
                    "controls": {
                        "1": "Custom cc name ",
                        "2": "Etc"
                    }
                },
                "2": {
                    "color" : "#9040ff"
                }
            }
        },
        "1": {
            "name": "Bass synth",
            "channels":{
                "0": {"name": "Trap bass"},
                "1": {"name": "Wobble"}
            }
        }
    }
}
```

This applies the color on the sequence button with an alpha channel to 0.125 (set transparency in the color in the config file has no effect). I don't know if this ratio is the best, it is hard to know because it depends a lot of the screen quality.
Normally, user should still recognize an active/passive/recording sequence.

