### PR TITLE
synchronize the sequence when /sequence/queue is received

### DIFF
--- a/src/core/sequence.h
+++ b/src/core/sequence.h
@@ -36,6 +36,14 @@ enum draw_type
     DRAW_NOTE_OFF
 };
 
+enum queued_mode
+{
+   QUEUED_NOT,
+   QUEUED_OFF,
+   QUEUED_ON
+};
+
+
 class sequence
 {
 
@@ -76,7 +84,7 @@ class sequence
     bool m_recording;
     bool m_quanized_rec;
     bool m_thru;
-    bool m_queued;
+    queued_mode m_queued;
     bool m_resume;
     bool m_resume_next;
 
@@ -190,8 +198,11 @@ class sequence
     void toggle_playing ();
 
     void toggle_queued(sequence * reference);
+    void set_on_queued(sequence * reference);
+    void set_off_queued(sequence * reference);
     void off_queued();
-    bool get_queued();
+    queued_mode get_queued();
+    bool is_queued();
     long get_queued_tick();
     long get_times_played();
     void set_resume(bool a_resume);

--- a/src/gui/sequencebutton.cpp
+++ b/src/gui/sequencebutton.cpp
@@ -148,7 +148,7 @@ SequenceButton::draw_background()
         name->show_in_cairo_context(cr);
 
         // queued ?
-        bool queued = get_sequence()->get_queued();
+        bool queued = get_sequence()->is_queued();
         int queued_width = 0;
         if (queued)
         {


### PR DESCRIPTION
synchronize the sequence when /sequence/queue is received, even if wanted playing state is the same than the current one.

fix #27 .

Now m_queued is an enum which can be QUEUED_NOT, QUEUED_OFF or QUEUED_ON, and the sequence is always re-synchronized after /sequence/queue has been received and sync reference sequence is restarted.

